### PR TITLE
feat: implement soft delete and ownership validation for comments

### DIFF
--- a/src/controllers/comment.controller.js
+++ b/src/controllers/comment.controller.js
@@ -5,15 +5,59 @@ const CommentService = require("../services/comment.service");
 
 class CommentController {
   async createComment(req, res, next) {
+    // Add userId from authenticated user
+    const { productId, content, parentCommentId } = req.body;
+
     new SuccessRespone({
-      message: "Create comment successful !",
-      metadata: await CommentService.createComment(req.body),
+      message: "Create comment successful!",
+      metadata: await CommentService.createComment({
+        productId,
+        userId: req.user.userId,
+        content,
+        parentCommentId,
+      }),
     }).send(res);
   }
+
   async getCommentsByParentId(req, res, next) {
     new SuccessRespone({
-      message: "List comment product",
+      message: "List comments for product",
       metadata: await CommentService.getCommentsByParentId(req.query),
+    }).send(res);
+  }
+
+  async updateComment(req, res, next) {
+    const { commentId, content } = req.body;
+
+    new SuccessRespone({
+      message: "Update comment successful!",
+      metadata: await CommentService.updateComment({
+        commentId,
+        userId: req.user.userId,
+        content,
+      }),
+    }).send(res);
+  }
+
+  async deleteComment(req, res, next) {
+    const { commentId, productId } = req.body;
+
+    new SuccessRespone({
+      message: "Delete comment successful!",
+      metadata: await CommentService.deleteComment({
+        commentId,
+        productId,
+        userId: req.user.userId,
+      }),
+    }).send(res);
+  }
+
+  async countComments(req, res, next) {
+    const { productId } = req.query;
+
+    new SuccessRespone({
+      message: "Count comments successful!",
+      metadata: await CommentService.countComments(productId),
     }).send(res);
   }
 }

--- a/src/models/repository/comment.repo.js
+++ b/src/models/repository/comment.repo.js
@@ -1,0 +1,166 @@
+"use strict";
+
+const { convertToObjectId } = require("../../utils");
+const commentModel = require("../comment.model");
+const { NotFoundResponse } = require("../../core/error.respone");
+
+class CommentRepository {
+  static async createComment(payload) {
+    const comment = new commentModel(payload);
+    return await comment.save();
+  }
+
+  static async findById(commentId) {
+    return await commentModel.findById(commentId);
+  }
+
+  static async findByIdAndUserId(commentId, userId) {
+    return await commentModel.findOne({
+      _id: convertToObjectId(commentId),
+      comment_userId: convertToObjectId(userId),
+      isDeleted: false,
+    });
+  }
+
+  static async getCommentsByParentId({
+    productId,
+    parentId = null,
+    limit = 50,
+    offset = 0,
+  }) {
+    if (parentId) {
+      const parent = await this.findById(parentId);
+      if (!parent) throw new NotFoundResponse("Parent comment not found");
+
+      return await commentModel
+        .find({
+          comment_productId: convertToObjectId(productId),
+          comment_left: { $gt: parent.comment_left },
+          comment_right: { $lt: parent.comment_right },
+          isDeleted: false,
+        })
+        .select({
+          comment_left: 1,
+          comment_right: 1,
+          comment_content: 1,
+          comment_userId: 1,
+          comment_parentId: 1,
+          createdAt: 1,
+          updatedAt: 1,
+        })
+        .populate("comment_userId", "name email")
+        .skip(offset)
+        .limit(limit)
+        .sort({ comment_left: 1 });
+    }
+
+    return await commentModel
+      .find({
+        comment_parentId: parentId,
+        comment_productId: convertToObjectId(productId),
+        isDeleted: false,
+      })
+      .select({
+        comment_left: 1,
+        comment_right: 1,
+        comment_content: 1,
+        comment_userId: 1,
+        comment_parentId: 1,
+        createdAt: 1,
+        updatedAt: 1,
+      })
+      .populate("comment_userId", "name email")
+      .skip(offset)
+      .limit(limit)
+      .sort({ comment_left: 1 });
+  }
+
+  static async findMaxRightValue(productId) {
+    return await commentModel.findOne(
+      {
+        comment_productId: convertToObjectId(productId),
+      },
+      "comment_right",
+      { sort: { comment_right: -1 } }
+    );
+  }
+
+  static async updateCommentsOnInsert(productId, rightValue) {
+    await Promise.all([
+      commentModel.updateMany(
+        {
+          comment_productId: convertToObjectId(productId),
+          comment_right: { $gte: rightValue },
+        },
+        {
+          $inc: { comment_right: 2 },
+        }
+      ),
+
+      commentModel.updateMany(
+        {
+          comment_productId: convertToObjectId(productId),
+          comment_left: { $gt: rightValue },
+        },
+        {
+          $inc: { comment_left: 2 },
+        }
+      ),
+    ]);
+  }
+
+  static async updateCommentsOnDelete(productId, left, width) {
+    await Promise.all([
+      commentModel.updateMany(
+        {
+          comment_productId: convertToObjectId(productId),
+          comment_right: { $gt: left + width },
+        },
+        {
+          $inc: { comment_right: -width },
+        }
+      ),
+
+      commentModel.updateMany(
+        {
+          comment_productId: convertToObjectId(productId),
+          comment_left: { $gt: left },
+        },
+        {
+          $inc: { comment_left: -width },
+        }
+      ),
+    ]);
+  }
+
+  static async markCommentsAsDeleted(productId, left, right) {
+    return await commentModel.updateMany(
+      {
+        comment_productId: convertToObjectId(productId),
+        comment_left: { $gte: left, $lte: right },
+      },
+      {
+        isDeleted: true,
+      }
+    );
+  }
+
+  static async updateComment(commentId, content) {
+    return await commentModel.findByIdAndUpdate(
+      commentId,
+      {
+        comment_content: content,
+      },
+      { new: true }
+    );
+  }
+
+  static async countByProductId(productId) {
+    return await commentModel.countDocuments({
+      comment_productId: convertToObjectId(productId),
+      isDeleted: false,
+    });
+  }
+}
+
+module.exports = CommentRepository;

--- a/src/routes/comment/index.js
+++ b/src/routes/comment/index.js
@@ -6,12 +6,13 @@ const { authenticationV2 } = require("../../auth/authUtils");
 const commentController = require("../../controllers/comment.controller");
 const router = express.Router();
 
+router.get("/get-list", asyncHandler(commentController.getCommentsByParentId));
+router.get("/count", asyncHandler(commentController.countComments));
+
 router.use(authenticationV2);
 
 router.post("/create", asyncHandler(commentController.createComment));
-router.get("/get-list", asyncHandler(commentController.getCommentsByParentId));
-// router.delete("/delete", asyncHandler(discountController.deleteDiscount));
-// router.patch("/cancel", asyncHandler(discountController.cancelDiscount));
-// router.patch("/update", asyncHandler(discountController.updateDiscount));
+router.patch("/update", asyncHandler(commentController.updateComment));
+router.delete("/delete", asyncHandler(commentController.deleteComment));
 
 module.exports = router;


### PR DESCRIPTION
- [x] Added ownership check to ensure users can only delete their own comments
- [x] Implemented soft delete using isDeleted flag instead of permanent removal
- [x] Updated CommentService.deleteComment to validate user permissions
- [x] Modified CommentController to pass userId when deleting a comment
- [x] Introduced countByProductId in CommentRepository to track comment count
- [x] Optimized error handling and validation for better API responses
Resolve issues #69 