### PR TITLE
chore: use $ prefix to reference fields for noti content (#73)

### DIFF
--- a/src/services/notification.service.js
+++ b/src/services/notification.service.js
@@ -52,7 +52,13 @@ class NotificationService {
         $project: {
           noti_type: 1,
           noti_senderId: 1,
-          noti_content: 1,
+          noti_content: {
+            $concat: [
+              "$noti_options.shop_name",
+              " vừa mới thêm một sản phẩm mới: ",
+              "$noti_options.product_name",
+            ],
+          },
           noti_options: 1,
           noti_receivedId: 1,
           createdAt: 1,


### PR DESCRIPTION
Using $ prefix to referance fields for notification content