### PR TITLE
fix: precondition failed (#94)

### DIFF
--- a/src/tests/message_queue/rabbitMQ/producerDLX.js
+++ b/src/tests/message_queue/rabbitMQ/producerDLX.js
@@ -1,9 +1,119 @@
+// const amqp = require("amqplib");
+
+// const log = console.log;
+// console.log = function () {
+//   log.apply(console, [new Date()].concat(arguments));
+// };
+// const runProducer = async () => {
+//   try {
+//     const connection = await amqp.connect("amqp://guest:12345@localhost:5672");
+//     const channel = await connection.createChannel();
+
+//     const notificationExchange = "notificationExchange";
+//     const notificationQueue = "notificationQueueProcess";
+//     const notificationExchangeDLX = "notificationExchangeDLX";
+//     const notificationRoutingKeyDLX = "notificationRoutingKeyDLX";
+
+//     // Delete the existing queue to avoid conflicts with changed parameters
+//     try {
+//       await channel.deleteQueue(notificationQueue);
+//       console.log(`Deleted existing queue: ${notificationQueue}`);
+//     } catch (err) {
+//       console.log(
+//         `Queue ${notificationQueue} might not exist yet, continuing...`
+//       );
+//     }
+
+//     // create Exchange
+//     await channel.assertExchange(notificationExchange, "direct", {
+//       durable: true,
+//     });
+
+//     // create Exchange for DLX
+//     await channel.assertExchange(notificationExchangeDLX, "direct", {
+//       durable: true,
+//     });
+
+//     // create Queue with TTL and a maximum message limit
+//     const queueResult = await channel.assertQueue(notificationQueue, {
+//       exclusive: false, // cho phep cac ket noi truy cap vao cung mot luc hang doi
+//       deadLetterExchange: notificationExchangeDLX,
+//       deadLetterRoutingKey: notificationRoutingKeyDLX,
+//       arguments: {
+//         "x-message-ttl": 10000, // 10 seconds TTL for the entire queue
+//         "x-max-length": 10, // Max number of messages in queue
+//         "x-overflow": "reject-publish", // Reject messages when queue is full
+//       },
+//     });
+
+//     // create binding
+//     await channel.bindQueue(queueResult.queue, notificationExchange, "");
+
+//     // send message - with delivery mode 2 (persistent)
+//     const message = "A new product was created!";
+//     await channel.sendToQueue(queueResult.queue, Buffer.from(message), {
+//       persistent: true, // Messages survive broker restart
+//       timestamp: Date.now(), // Add timestamp for tracking
+//     });
+//     console.log(`Message sent: ${message}`);
+
+//     setTimeout(() => {
+//       connection.close();
+//       process.exit(0);
+//     }, 1000);
+//   } catch (error) {
+//     console.log("Error rabbitmq:", error);
+//   }
+// };
+
+// runProducer().catch((err) => console.log(err));
+// const amqp = require("amqplib");
+
+// const runProducer = async () => {
+//   try {
+//     const connection = await amqp.connect("amqp://guest:12345@localhost:5672");
+//     const channel = await connection.createChannel();
+
+//     const notificationExchange = "notificationExchange";
+//     const notificationQueue = "notificationQueueProcess";
+//     const notificationExchangeDLX = "notificationExchangeDLX";
+//     const notificationRoutingKeyDLX = "notificationRoutingKeyDLX";
+
+//     // 1. create exchange
+//     await channel.assertExchange(notificationExchange, "direct", {
+//       durable: true,
+//     });
+
+//     // 2. create queue
+//     const queueResult = await channel.assertQueue(notificationQueue, {
+//       exclusive: false,
+//       deadLetterExchange: notificationExchangeDLX,
+//       deadLetterRoutingKey: notificationRoutingKeyDLX,
+//     });
+
+//     // 3. binding exchange
+//     await channel.bindQueue(queueResult.queue, notificationExchange);
+
+//     // 4. Send message
+//     const msg = "A new product was created";
+//     await channel.sendToQueue(queueResult.queue, Buffer.from(msg), {
+//       expiration: "10000",
+//     });
+//     console.log(`A message was sent::${msg}`);
+
+//     setTimeout(() => {
+//       connection.close();
+//       console.log("Connection closed");
+//     }, 1000);
+//   } catch (error) {
+//     console.log("Error rabbitmq: ", error);
+//   }
+// };
+
+// runProducer().catch((err) => console.log(err));
+
 const amqp = require("amqplib");
 
-const log = console.log;
-console.log = function () {
-  log.apply(console, [new Date()].concat(arguments));
-};
 const runProducer = async () => {
   try {
     const connection = await amqp.connect("amqp://guest:12345@localhost:5672");
@@ -14,55 +124,40 @@ const runProducer = async () => {
     const notificationExchangeDLX = "notificationExchangeDLX";
     const notificationRoutingKeyDLX = "notificationRoutingKeyDLX";
 
-    // Delete the existing queue to avoid conflicts with changed parameters
-    try {
-      await channel.deleteQueue(notificationQueue);
-      console.log(`Deleted existing queue: ${notificationQueue}`);
-    } catch (err) {
-      console.log(
-        `Queue ${notificationQueue} might not exist yet, continuing...`
-      );
-    }
-
-    // create Exchange
+    // 1. create exchange
     await channel.assertExchange(notificationExchange, "direct", {
       durable: true,
     });
 
-    // create Exchange for DLX
-    await channel.assertExchange(notificationExchangeDLX, "direct", {
-      durable: true,
-    });
-
-    // create Queue with TTL and a maximum message limit
+    // 2. create queue with consistent parameters
     const queueResult = await channel.assertQueue(notificationQueue, {
-      exclusive: false, // cho phep cac ket noi truy cap vao cung mot luc hang doi
+      exclusive: false,
+      durable: true,
       deadLetterExchange: notificationExchangeDLX,
       deadLetterRoutingKey: notificationRoutingKeyDLX,
       arguments: {
-        "x-message-ttl": 10000, // 10 seconds TTL for the entire queue
-        "x-max-length": 10, // Max number of messages in queue
-        "x-overflow": "reject-publish", // Reject messages when queue is full
+        "x-message-ttl": 10000, // Set TTL at queue level for consistency
       },
     });
 
-    // create binding
-    await channel.bindQueue(queueResult.queue, notificationExchange, "");
+    // 3. binding exchange with a routing key
+    await channel.bindQueue(
+      queueResult.queue,
+      notificationExchange,
+      "" // Use an empty string as default routing key
+    );
 
-    // send message - with delivery mode 2 (persistent)
-    const message = "A new product was created!";
-    await channel.sendToQueue(queueResult.queue, Buffer.from(message), {
-      persistent: true, // Messages survive broker restart
-      timestamp: Date.now(), // Add timestamp for tracking
-    });
-    console.log(`Message sent: ${message}`);
+    // 4. Send message (without setting expiration at message level)
+    const msg = "A new product was created";
+    await channel.sendToQueue(queueResult.queue, Buffer.from(msg));
+    console.log(`A message was sent::${msg}`);
 
     setTimeout(() => {
       connection.close();
-      process.exit(0);
+      console.log("Connection closed");
     }, 1000);
   } catch (error) {
-    console.log("Error rabbitmq:", error);
+    console.log("Error rabbitmq: ", error);
   }
 };
 


### PR DESCRIPTION
The specific issue is that setting message expiration at the message level with:
```
await channel.sendToQueue(queueResult.queue, Buffer.from(msg), {
  expiration: "10000",
});
```

But the queue might have been previously created with different TTL settings.