### PR TITLE
feat: add API for search comments by rating range and support decimal…

### DIFF
--- a/src/controllers/comment.controller.js
+++ b/src/controllers/comment.controller.js
@@ -56,7 +56,7 @@ class CommentController {
       message: "Get comment by rating successfully",
       metadata: await CommentService.getCommentsByRating({
         productId,
-        rating: Number(rating),
+        rating: rating,
         limit: limit ? Number(limit) : 50,
         offset: offset ? Number(offset) : 0,
       }),
@@ -72,6 +72,21 @@ class CommentController {
         commentId,
         productId,
         userId: req.user.userId,
+      }),
+    }).send(res);
+  }
+
+  async getCommentsByRatingRange(req, res, next) {
+    const { productId, minRating, maxRating, limit, offset } = req.query;
+    
+    new SuccessResponse({
+      message: "Get comments by rating range successfully",
+      metadata: await CommentService.getCommentsByRatingRange({
+        productId,
+        minRating: parseFloat(minRating || 1),
+        maxRating: parseFloat(maxRating || 5),
+        limit: limit ? Number(limit) : 50,
+        offset: offset ? Number(offset) : 0,
       }),
     }).send(res);
   }

--- a/src/models/comment.model.js
+++ b/src/models/comment.model.js
@@ -36,6 +36,7 @@ const commentSchema = new Schema(
       min: 1,
       max: 5,
       default: null,
+      set: (val) => (val ? Math.round(val * 10) / 10 : null),
     },
 
     images: [

--- a/src/routes/comment/index.js
+++ b/src/routes/comment/index.js
@@ -13,7 +13,10 @@ router.get(
   "/ratings/summary",
   asyncHandler(commentController.getProductRatingSummary),
 );
-
+router.get(
+  "/ratings/range",
+  asyncHandler(commentController.getCommentsByRatingRange)
+);
 router.get(
   "/ratings/filter",
   asyncHandler(commentController.getCommentsByRating),


### PR DESCRIPTION
- Update comment model to properly handle decimal ratings
- Modify getCommentsByRating to support exact decimal matches
- Use parseFloat instead of Number for rating conversions
- Ensure consistent validation for decimal ratings across all methods
- Fix bug where ratings like 3.5 returned empty results
- Add new getCommentsByRatingRange repository method
- Implement service method to handle rating range queries
- Create controller endpoint for rating range filter
- Add new API route at /ratings/range
- Allow flexible querying of comments within specified rating bounds